### PR TITLE
[feat: add option to include homebrew classes in ClassMultiSelect

### DIFF
--- a/src/components/class/ClassMultiSelect.tsx
+++ b/src/components/class/ClassMultiSelect.tsx
@@ -46,11 +46,11 @@ export const ClassMultiSelect = ({
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   // Fetch options based on search query
-  const fetchOptions = async (query: string) => {
+  const fetchOptions = async (query: string, homebrew: boolean) => {
     if (!query) return;
     setLoading(true);
     try {
-      const data = await classSearchHelper(query);
+      const data = await classSearchHelper(query, homebrew);
       if (data) {
         setOptions(
           data.map((item) => ({
@@ -101,7 +101,7 @@ export const ClassMultiSelect = ({
 
   useEffect(() => {
     if (input.trim().length > 0) {
-      void debouncedFetch(input);
+      void debouncedFetch(input, includedHomebrew);
     } else if (isFocused) {
       void fetchClasses();
     } else {

--- a/src/components/class/ClassMultiSelect.tsx
+++ b/src/components/class/ClassMultiSelect.tsx
@@ -76,6 +76,8 @@ export const ClassMultiSelect = ({
         ? await getAllClasses()
         : await getAllBaseClasses();
       if (data) {
+        // FIXME: Currently, Class.name is not a required field. The assertion here is just to make sorting work for now.
+        data.sort((a, b) => (a.name! > b.name! ? 1 : -1));
         setOptions(
           data.map((item) => ({
             value: Number(item.id),

--- a/src/components/class/ClassMultiSelect.tsx
+++ b/src/components/class/ClassMultiSelect.tsx
@@ -76,8 +76,13 @@ export const ClassMultiSelect = ({
         ? await getAllClasses()
         : await getAllBaseClasses();
       if (data) {
-        // FIXME: Currently, Class.name is not a required field. The assertion here is just to make sorting work for now.
-        data.sort((a, b) => (a.name! > b.name! ? 1 : -1));
+        // Sort classes by name, placing items with null/undefined names at the end
+        data.sort((a, b) => {
+          if (!a.name && !b.name) return 0;
+          if (!a.name) return 1;
+          if (!b.name) return -1;
+          return a.name.localeCompare(b.name);
+        });
         setOptions(
           data.map((item) => ({
             value: Number(item.id),
@@ -86,7 +91,7 @@ export const ClassMultiSelect = ({
         );
       }
     } catch (err) {
-      console.error("getAllBaseClasses failed:", err);
+      console.error("Failed to fetch character classes:", err);
       setOptions([]);
     } finally {
       setLoading(false);
@@ -109,7 +114,7 @@ export const ClassMultiSelect = ({
     } else {
       setOptions([]);
     }
-  }, [input, debouncedFetch, isFocused]);
+  }, [input, debouncedFetch, isFocused, includedHomebrew]);
 
   const handleBlur = (e: FocusEvent) => {
     // Only close dropdown if focus leaves the whole wrapper
@@ -205,14 +210,16 @@ export const ClassMultiSelect = ({
                 <label
                   className="flex items-center gap-1"
                   htmlFor={`${name}-includeHomebrew`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
                 >
                   Include Homebrew?
                   <Checkbox
                     id={`${name}-includeHomebrew`}
                     className="ml-2"
                     checked={includedHomebrew}
-                    onClick={(e) => {
-                      e.stopPropagation();
+                    onCheckedChange={() => {
                       handleToggleIncludeHomebrew();
                     }}
                   />

--- a/src/integrations/supabase/helpers/classes.ts
+++ b/src/integrations/supabase/helpers/classes.ts
@@ -306,13 +306,20 @@ export const createNewHomebrewClass = async (
 };
 
 export const classSearchHelper = async (
-  query: string
+  query: string,
+  homebrew = false
 ): Promise<Class[] | null> => {
-  const { data, error } = await supabase
+  const baseQuery = supabase
     .from("classes")
     .select()
     .ilike("name", `%${query}%`)
     .limit(20);
+
+  if (!homebrew) {
+    baseQuery.eq("isHomebrew", false);
+  }
+
+  const { data, error } = await baseQuery;
 
   if (error) {
     console.log(error);


### PR DESCRIPTION
The `ClassMultiSelect` component only shows base character classes by default, but will show homebrew in a search. This PR adds an "Include Homebrew" toggle to the search field to allow the user to determine whether they want to see all available classes or just the base Daggerheart classes.

This PR also adds alphabetical sorting to the options field.

**Known Issues**

- ~~`Class.name` is a nullable field, which can break the sorting if it is not defined. Should we make that field required or not worry about sorting? (Ref [ClassMultiSelect.tsx:80](https://github.com/blueknightone/daggerheart-forge-interactive-sheets/blob/6465fb970faa415d2a0e11698455b6fea09778ff/src/components/class/ClassMultiSelect.tsx#L80))~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional "Include Homebrew" toggle to the class selection component, allowing users to include or exclude homebrew classes from the available options.

- **Enhancements**
  - Improved class search functionality to respect the "Include Homebrew" setting, providing more tailored search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->